### PR TITLE
Amendment to remove mention of derivative catalogs

### DIFF
--- a/4eliminate.tex
+++ b/4eliminate.tex
@@ -6,7 +6,7 @@ A subset of streaks, potentially consistent with Earth-orbiting satellites or So
 will be determined by comparison with an appropriate catalog or catalogs at the \gls{USDF}.
 Any object that corresponds to an object in this catalog will not be released in the  prompt
 alerts or stored in the prompt alert database.
-Any catalog that SLAC creates noting these corresponding identifications will be held at the OFFICIAL USE ONLY level within the \gls{USDF} at \gls{SLAC} and have appropriate export-controls and \gls{FOIA} exemptions.
+SLAC will not create any catalogs noting these corresponding notifications.
 Additionally no streaks will be  alerted on with a streak length greater than 10 deg/day relative to sidereal.
 In the rare event an unknown solar system object source with a streak  length greater than 10 deg/day potentially corresponds with an Earth-impacting asteroid, SLAC shall implement a method to send any candidate  impactors to the Minor Planet Center during the embargo period, complying with encryption standards for data in transit during the embargo  period.
 

--- a/4eliminate.tex
+++ b/4eliminate.tex
@@ -6,7 +6,7 @@ A subset of streaks, potentially consistent with Earth-orbiting satellites or So
 will be determined by comparison with an appropriate catalog or catalogs at the \gls{USDF}.
 Any object that corresponds to an object in this catalog will not be released in the  prompt
 alerts or stored in the prompt alert database.
-SLAC will not create any catalogs noting these corresponding notifications.
+SLAC will not create any catalogs with information corresponding to these object.
 Additionally no streaks will be  alerted on with a streak length greater than 10 deg/day relative to sidereal.
 In the rare event an unknown solar system object source with a streak  length greater than 10 deg/day potentially corresponds with an Earth-impacting asteroid, SLAC shall implement a method to send any candidate  impactors to the Minor Planet Center during the embargo period, complying with encryption standards for data in transit during the embargo  period.
 

--- a/4eliminate.tex
+++ b/4eliminate.tex
@@ -6,7 +6,7 @@ A subset of streaks, potentially consistent with Earth-orbiting satellites or So
 will be determined by comparison with an appropriate catalog or catalogs at the \gls{USDF}.
 Any object that corresponds to an object in this catalog will not be released in the  prompt
 alerts or stored in the prompt alert database.
-SLAC will not create any catalogs with information corresponding to these object.
+SLAC will not create any catalogs with information corresponding to these objects.
 Additionally no streaks will be  alerted on with a streak length greater than 10 deg/day relative to sidereal.
 In the rare event an unknown solar system object source with a streak  length greater than 10 deg/day potentially corresponds with an Earth-impacting asteroid, SLAC shall implement a method to send any candidate  impactors to the Minor Planet Center during the embargo period, complying with encryption standards for data in transit during the embargo  period.
 

--- a/DMTN-199.tex
+++ b/DMTN-199.tex
@@ -54,6 +54,7 @@ In this document we describe a set of measures that we plan to take, in order to
   \addtohist{1.2}{2022-10-04}{Include notes on working with commissioning data}{Phil Marshall}
   \addtohist{1.3}{2022-10-26}{Embargo clarification}{William O'Mullane}
   \addtohist{2.0}{2023-06-08}{Updated Requirements from NSF and DOE. Include agency oversight.}{William O'Mullane, Bob Blum, Phil Marshall}
+  \addtohist{2.1}{2024-07-12}{Removed mention of derivative catalogs}{Phil Marshall}
 }
 
 

--- a/DMTN-199.tex
+++ b/DMTN-199.tex
@@ -23,7 +23,7 @@ Cristi\'{a}n Silva,
 Ian Sullivan,
 Kian-Tat Lim,
 Phil Marshall\\
-Agency oversight: Ashley Zauderer-Vanderley (NSF), Kathy Turner (DOE)
+Agency oversight: Ashley Zauderer-Vanderley (NSF), Helmut Marsiske (DOE)
 }
 
 \setDocRef{DMTN-199}


### PR DESCRIPTION
This is a small and straightforward amendment, that tightens security around the removal of artificial satellites. We do not plan on storing any identifications arising from the alert-vetting satellite cross-matching process, and so we can simply remove all mention of derivative catalogs and how to handle them.