### PR TITLE
80-hour embargo period in survey-mode LSSTCam commissioning

### DIFF
--- a/DMTN-199.tex
+++ b/DMTN-199.tex
@@ -29,7 +29,7 @@ Agency oversight: Ashley Zauderer-Vanderley (NSF), Helmut Marsiske (DOE)
 \setDocRef{DMTN-199}
 \setDocUpstreamLocation{\url{https://github.com/lsst-dm/dmtn-199}}
 
-\date{2024-09-16}
+\date{2025-01-13}
 %\date{\vcsDate}
 
 % Optional: name of the document's curator
@@ -57,6 +57,7 @@ In this document we describe a set of measures that we plan to take, in order to
   \addtohist{2.1}{2024-07-12}{Removed mention of derivative catalogs}{Phil Marshall}
   \addtohist{2.2}{2024-08-02}{Remove compliance appendix - point to RTN-082}{William O'Mullane}
   \addtohist{2.3}{2024-09-16}{Make ComCam exemption explicit - tidy some embargo wording}{William O'Mullane, Phil Marshall}
+  \addtohist{2.4}{2025-01-13}{80-hour embargo period in survey-mode LSSTCam commissioning.}{Phil Marshall}
 }
 
 


### PR DESCRIPTION
Small amendment to clarify that the embargo period will be reduced to 80 hours as soon as we enter "survey-mode" observing with LSSTCam, i.e. after System First Light. At this point we will no longer be doing engineering observations, and will have passed Data Management Standards Review 3 (DMSR3).

I'll tag @womullan and @ktlim as reviewers when the text is ready, and flag this to Adam and Bob then as well. We won't merge this PR until we Helmut and Ashley sign off (which I will orchestrate outside of GitHub, when we have a PDF we are happy with). 